### PR TITLE
Move filters to context and update styles

### DIFF
--- a/src/panel/App.tsx
+++ b/src/panel/App.tsx
@@ -8,7 +8,8 @@ import { Request } from "./request/Request";
 import {
   DevtoolsProvider,
   OperationProvider,
-  RequestProvider
+  RequestProvider,
+  FilterProvider
 } from "./context";
 
 const theme = {
@@ -46,13 +47,15 @@ export const App = () => {
     <DevtoolsProvider>
       <ThemeProvider theme={theme}>
         <HashRouter>
-          <OperationProvider>
-            <Route path="/events" component={Events} />
-          </OperationProvider>
-          <RequestProvider>
-            <Route path="/request" component={Request} />
-          </RequestProvider>
-          <Navigation />
+          <FilterProvider>
+            <OperationProvider>
+              <Route path="/events" component={Events} />
+            </OperationProvider>
+            <RequestProvider>
+              <Route path="/request" component={Request} />
+            </RequestProvider>
+            <Navigation />
+          </FilterProvider>
         </HashRouter>
       </ThemeProvider>
     </DevtoolsProvider>

--- a/src/panel/context/Filter.tsx
+++ b/src/panel/context/Filter.tsx
@@ -1,0 +1,54 @@
+import React, { createContext, FC, useState } from "react";
+
+import { UrqlEvent } from "../../types";
+
+export enum FilterType {
+  Name = "name",
+  Key = "key",
+  Info = "info"
+}
+
+interface Filter {
+  value: string;
+  propName: FilterType;
+  propGetter: (e: UrqlEvent) => string | number;
+}
+
+interface FilterContextValue {
+  filters: Filter[];
+  addFilter: (filter: Filter) => void;
+  removeFilter: (filter: Filter) => void;
+}
+
+export const FilterContext = createContext<FilterContextValue>(
+  undefined as any
+);
+
+function filterFilters(filters: Filter[], incomingFilter: Filter) {
+  return filters.filter(
+    f =>
+      f.value !== incomingFilter.value && f.propName !== incomingFilter.propName
+  );
+}
+
+export const FilterProvider: FC = ({ children }) => {
+  const [filters, setFilters] = useState<Filter[]>([]);
+
+  const addFilter = (filter: Filter) => {
+    return setFilters([filter, ...filterFilters(filters, filter)]);
+  };
+
+  const removeFilter = (filter: Filter) => {
+    return setFilters(filterFilters(filters, filter));
+  };
+
+  const value = {
+    filters,
+    addFilter,
+    removeFilter
+  };
+
+  return (
+    <FilterContext.Provider value={value}>{children}</FilterContext.Provider>
+  );
+};

--- a/src/panel/context/index.ts
+++ b/src/panel/context/index.ts
@@ -1,3 +1,4 @@
 export * from "./Devtools";
 export * from "./Events";
 export * from "./Request";
+export * from "./Filter";

--- a/src/panel/events/EventCard.tsx
+++ b/src/panel/events/EventCard.tsx
@@ -1,19 +1,20 @@
 import React, { FC, useContext, useCallback } from "react";
 import styled, { ThemeContext, css } from "styled-components";
 import { UrqlEvent } from "../../types";
-import { EventsContext } from "../context";
+import { EventsContext, FilterContext, FilterType } from "../context";
 
 /** Shows basic information about an operation. */
 export const EventCard: FC<{
   operation: UrqlEvent;
   active: boolean;
-  setFilter: any;
   canFilter: boolean;
-}> = ({ operation, setFilter, canFilter, active = false }) => {
+}> = ({ operation, canFilter, active = false }) => {
   const theme = useContext(ThemeContext);
   const { selectedEvent, selectEvent, clearSelectedEvent } = useContext(
     EventsContext
   );
+
+  const { addFilter } = useContext(FilterContext);
 
   const handleContainerClick = useCallback(() => {
     // if we're currently in filtering mode, ignore container clicks
@@ -51,18 +52,13 @@ export const EventCard: FC<{
     date: formatDate(operation.timestamp)
   };
 
-  const makeSetFilter = (type: string) => {
+  const makeSetFilter = (type: FilterType) => {
     return () =>
       canFilter
-        ? setFilter({
-            payload: {
-              filter: {
-                value: values[type],
-                propName: type,
-                propGetter: valueGetters[type]
-              }
-            },
-            type: "add"
+        ? addFilter({
+            value: values[type],
+            propName: type,
+            propGetter: valueGetters[type]
           })
         : () => {
             /*noop*/
@@ -72,16 +68,25 @@ export const EventCard: FC<{
   return (
     <Container onClick={handleContainerClick} aria-selected={active}>
       <Indicator
-        style={{ backgroundColor: colors[values["name"].toString()] }}
+        style={{ backgroundColor: colors[values[FilterType.Name].toString()] }}
       />
-      <OperationName onClick={makeSetFilter("name")} isActive={canFilter}>
+      <OperationName
+        onClick={makeSetFilter(FilterType.Name)}
+        isActive={canFilter}
+      >
         {values["name"]}
       </OperationName>
       <OperationTime>{values["date"]}</OperationTime>
-      <OperationAddInfo onClick={makeSetFilter("info")} isActive={canFilter}>
+      <OperationAddInfo
+        onClick={makeSetFilter(FilterType.Info)}
+        isActive={canFilter}
+      >
         {values["info"] || "Unknown"}
       </OperationAddInfo>
-      <OperationKey onClick={makeSetFilter("key")} isActive={canFilter}>
+      <OperationKey
+        onClick={makeSetFilter(FilterType.Key)}
+        isActive={canFilter}
+      >
         {values["key"]}
       </OperationKey>
     </Container>
@@ -131,7 +136,9 @@ const OperationName = styled.h3`
     width: 20%;
   }
 
-  ${getActiveStyles}
+  &:hover {
+    ${getActiveStyles}
+  }
 `;
 
 const OperationTime = styled.p`
@@ -160,7 +167,9 @@ const OperationAddInfo = styled.p`
     width: 25%;
   }
 
-  ${getActiveStyles}
+  &:hover {
+    ${getActiveStyles}
+  }
 `;
 
 const OperationKey = styled.p`
@@ -179,7 +188,9 @@ const OperationKey = styled.p`
     width: 25%;
   }
 
-  ${getActiveStyles}
+  &:hover {
+    ${getActiveStyles}
+  }
 `;
 
 const Indicator = styled.div`


### PR DESCRIPTION
Fixes issue in #24 where filters weren't persisting between tabs and addresses some PR comments, updates filter styles.

<img width="700" alt="Screenshot 2019-06-28 at 00 22 50" src="https://user-images.githubusercontent.com/17658189/60307067-e6275100-993a-11e9-89a2-4ae249ca5207.png">


<img width="698" alt="Screenshot 2019-06-28 at 00 18 14" src="https://user-images.githubusercontent.com/17658189/60307011-9c3e6b00-993a-11e9-8399-59fb911d289c.png">


