### PR TITLE
(fix) - invalid utf-8 character in minified output

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,7 @@ module.exports = {
         sourceMap: true,
         terserOptions: {
           output: {
+            ascii_only: true,
             comments: false,
           }
         },


### PR DESCRIPTION
puts terser in ascii-only mode to prevent the conversion to utf-8 since this causes an invalid character in the request screen.