### PR TITLE
(feat) - clear list on disconnect

### DIFF
--- a/src/background/EventTarget.ts
+++ b/src/background/EventTarget.ts
@@ -3,7 +3,7 @@ export class BackgroundEventTarget<T extends any = any> {
   private listeners: Record<string, Handler<T> | undefined> = {};
 
   public addEventListener(source: string, callback: Handler<T>) {
-    console.log("adding lsitenet", source);
+    console.log("adding listener", source);
     this.listeners[source] = callback;
   }
 

--- a/src/panel/context/Devtools.tsx
+++ b/src/panel/context/Devtools.tsx
@@ -65,6 +65,9 @@ export const DevtoolsProvider: FC = ({ children }) => {
     addMessageHandler(
       message => message.type === "init" && setClientConnected(true)
     );
+    addMessageHandler(
+      message => message.type === "disconnect" && setClientConnected(false)
+    );
   }, [addMessageHandler, setClientConnected]);
   console.log(clientConnected);
 

--- a/src/panel/context/Events.tsx
+++ b/src/panel/context/Events.tsx
@@ -9,6 +9,13 @@ import React, {
   useCallback
 } from "react";
 import {
+  DevtoolsExchangeOutgoingMessage,
+  OperationMessage,
+  OperationResponseMessage,
+  OperationErrorMessage,
+  InitMessage
+} from "@urql/devtools";
+import {
   ParsedEvent,
   ParsedMutationEvent,
   ParsedQueryEvent,
@@ -19,13 +26,6 @@ import {
   ParsedTeardownEvent
 } from "../types";
 import { DevtoolsContext } from "./Devtools";
-import {
-  DevtoolsExchangeOutgoingMessage,
-  OperationMessage,
-  OperationResponseMessage,
-  OperationErrorMessage,
-  InitMessage
-} from "@urql/devtools";
 
 export interface EventsContextValue {
   events: ParsedEvent[];
@@ -54,7 +54,7 @@ type PresentedEvent = Exclude<DevtoolsExchangeOutgoingMessage, InitMessage>;
 export const EventsContext = createContext<EventsContextValue>(null as any);
 
 export const EventsProvider: FC = ({ children }) => {
-  const { addMessageHandler } = useContext(DevtoolsContext);
+  const { addMessageHandler, clientConnected } = useContext(DevtoolsContext);
   const [rawEvents, setRawEvents] = useState<PresentedEvent[]>([]);
   const [selectedEvent, setSelectedEvent] = useState<ParsedEvent | undefined>(
     undefined
@@ -65,16 +65,11 @@ export const EventsProvider: FC = ({ children }) => {
     key: []
   });
 
-  // /** Set initial state from cache */
-  // useEffect(() => {
-  //   window.chrome.devtools.inspectedWindow.eval(
-  //     `window.__urql__.events`,
-  //     (ops: UrqlEvent[]) => {
-  //       console.log(ops);
-  //       setRawEvents(ops);
-  //     }
-  //   );
-  // }, []);
+  useEffect(() => {
+    if (!clientConnected) {
+      setRawEvents([]);
+    }
+  }, [clientConnected]);
 
   /** Handle incoming events */
   useEffect(() => {

--- a/src/panel/context/Request.tsx
+++ b/src/panel/context/Request.tsx
@@ -64,7 +64,7 @@ export const RequestProvider: FC = ({ children }) => {
   // Get schema
   useEffect(() => {
     chrome.devtools.inspectedWindow.eval(
-      "window.__urql__.client.url",
+      "window.__urql__.url",
       async endpoint => {
         const link = new HttpLink({
           uri: endpoint as string,


### PR DESCRIPTION
This was a lot harder than it should've been, the clue that I didn't realise is that the `background` has a separate console window that has to be opened from `chrome://extensions` this made me think there were no disconnect events triggering... Got there in the end :D