### PR TITLE
(chore) - add resolution for react and react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,9 @@
   "peerDependencies": {
     "react": ">= 16.8.0",
     "urql": ">= 1.2.0"
+  },
+  "resolutions": {
+    "@types/react": "16.9.2",
+    "@types/react-dom": "16.9.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -352,7 +352,7 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
-"@types/react-dom@^16.8.4":
+"@types/react-dom@16.9.0", "@types/react-dom@^16.8.4":
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.0.tgz#ba6ddb00bf5de700b0eb91daa452081ffccbfdea"
   integrity sha512-OL2lk7LYGjxn4b0efW3Pvf2KBVP0y1v3wip1Bp7nA79NkOpElH98q3WdCEdDj93b2b0zaeBG9DvriuKjIK5xDA==
@@ -391,7 +391,7 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.8.22":
+"@types/react@*", "@types/react@16.9.2", "@types/react@^16.8.22":
   version "16.9.2"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.2.tgz#6d1765431a1ad1877979013906731aae373de268"
   integrity sha512-jYP2LWwlh+FTqGd9v7ynUKZzjj98T8x7Yclz479QdRhHfuW9yQ+0jjnD31eXSXutmBpppj5PYNLYLRfnZJvcfg==


### PR DESCRIPTION
adds a resolution for react and react-dom types to stop build from errorring out on multiple versions of these libraries. This most commonly happens due to a sub library requiring @types/react on a certain version instead of using an operator specifying the version