### PR TITLE
Add Tooltips to the Event Timeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "dependencies": {
     "bestzip": "^2.1.4",
+    "d3-scale": "^3.2.1",
     "fast-json-stable-stringify": "^2.0.0",
     "nanoid": "^2.1.0",
     "prism-react-renderer": "^1.0.2",
@@ -73,6 +74,7 @@
     "@babel/preset-typescript": "^7.7.2",
     "@types/chrome": "0.0.86",
     "@types/codemirror": "0.0.76",
+    "@types/d3-scale": "^2.2.0",
     "@types/enzyme": "^3.10.3",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/fast-json-stable-stringify": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@types/react-json-tree": "^0.6.11",
     "@types/react-router": "^5.0.2",
     "@types/react-router-dom": "^4.3.4",
+    "@types/resize-observer-browser": "^0.1.3",
     "@types/styled-components": "^4.1.18",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",

--- a/src/panel/context/Timeline.tsx
+++ b/src/panel/context/Timeline.tsx
@@ -10,10 +10,6 @@ import React, {
 } from "react";
 import { scaleLinear } from "d3-scale";
 import { ParsedEvent } from "../types";
-import {
-  TimelineTooltip,
-  TooltipPosition
-} from "../pages/timeline/components/TimelineTooltip";
 import { DevtoolsContext } from "./Devtools";
 
 interface TimelineContextValue {
@@ -21,9 +17,6 @@ interface TimelineContextValue {
   setContainer: (e: HTMLDivElement) => void;
   getTimePosition: (t: number) => number;
   timelineLength: number;
-  setTooltipPosition: React.Dispatch<
-    React.SetStateAction<TooltipPosition | null>
-  >;
 }
 
 const TimelineContext = createContext<TimelineContextValue>(null as any);
@@ -81,11 +74,6 @@ export const TimelineProvider: FC = ({ children }) => {
   const { addMessageHandler } = useContext(DevtoolsContext);
   const domain = useTimelineDomain();
   const [events, setEvents] = useState<Record<string, ParsedEvent[]>>({});
-  // TODO: add tooltip message state
-  const [
-    tooltipPosition,
-    setTooltipPosition
-  ] = React.useState<TooltipPosition | null>(null);
 
   useEffect(() => {
     return addMessageHandler(message => {
@@ -107,7 +95,6 @@ export const TimelineProvider: FC = ({ children }) => {
   const value = useMemo(
     () => ({
       events,
-      setTooltipPosition,
       ...domain
     }),
     [domain, events]
@@ -115,9 +102,6 @@ export const TimelineProvider: FC = ({ children }) => {
 
   return (
     <TimelineContext.Provider value={value}>
-      {/* TimelineTooltip rendered here so the position
-          doesn't have to be passed with the setter */}
-      {tooltipPosition && <TimelineTooltip position={tooltipPosition} />}
       {children}
     </TimelineContext.Provider>
   );

--- a/src/panel/context/Timeline.tsx
+++ b/src/panel/context/Timeline.tsx
@@ -10,6 +10,10 @@ import React, {
 } from "react";
 import { scaleLinear } from "d3-scale";
 import { ParsedEvent } from "../types";
+import {
+  TimelineTooltip,
+  TooltipPosition
+} from "../pages/timeline/components/TimelineTooltip";
 import { DevtoolsContext } from "./Devtools";
 
 interface TimelineContextValue {
@@ -17,6 +21,9 @@ interface TimelineContextValue {
   setContainer: (e: HTMLDivElement) => void;
   getTimePosition: (t: number) => number;
   timelineLength: number;
+  setTooltipPosition: React.Dispatch<
+    React.SetStateAction<TooltipPosition | null>
+  >;
 }
 
 const TimelineContext = createContext<TimelineContextValue>(null as any);
@@ -74,6 +81,11 @@ export const TimelineProvider: FC = ({ children }) => {
   const { addMessageHandler } = useContext(DevtoolsContext);
   const domain = useTimelineDomain();
   const [events, setEvents] = useState<Record<string, ParsedEvent[]>>({});
+  // TODO: add tooltip message state
+  const [
+    tooltipPosition,
+    setTooltipPosition
+  ] = React.useState<TooltipPosition | null>(null);
 
   useEffect(() => {
     return addMessageHandler(message => {
@@ -95,6 +107,7 @@ export const TimelineProvider: FC = ({ children }) => {
   const value = useMemo(
     () => ({
       events,
+      setTooltipPosition,
       ...domain
     }),
     [domain, events]
@@ -102,6 +115,9 @@ export const TimelineProvider: FC = ({ children }) => {
 
   return (
     <TimelineContext.Provider value={value}>
+      {/* TimelineTooltip rendered here so the position
+          doesn't have to be passed with the setter */}
+      {tooltipPosition && <TimelineTooltip position={tooltipPosition} />}
       {children}
     </TimelineContext.Provider>
   );

--- a/src/panel/pages/timeline/components/TimelineEvent.fixture.tsx
+++ b/src/panel/pages/timeline/components/TimelineEvent.fixture.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import styled from "styled-components";
 import { ParsedEvent } from "../../../types";
-import { TimelineProvider } from "../../../context/Timeline";
 import { TimelineEvent } from "./TimelineEvent";
 
 const Wrapper = styled.div`
@@ -9,6 +8,7 @@ const Wrapper = styled.div`
   padding: 10px;
   background: ${props => props.theme.dark["0"]};
   flex-grow: 1;
+  padding: 100px;
 `;
 
 const queryEvent: ParsedEvent = {
@@ -65,12 +65,5 @@ export default {
     <Wrapper>
       <TimelineEvent event={teardownEvent} />
     </Wrapper>
-  ),
-  "event with tooltip": (
-    <TimelineProvider>
-      <Wrapper>
-        <TimelineEvent event={queryEvent} />
-      </Wrapper>
-    </TimelineProvider>
   )
 };

--- a/src/panel/pages/timeline/components/TimelineEvent.fixture.tsx
+++ b/src/panel/pages/timeline/components/TimelineEvent.fixture.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { ParsedEvent } from "../../../types";
+import { TimelineProvider } from "../../../context/Timeline";
 import { TimelineEvent } from "./TimelineEvent";
 
 const Wrapper = styled.div`
@@ -64,5 +65,12 @@ export default {
     <Wrapper>
       <TimelineEvent event={teardownEvent} />
     </Wrapper>
+  ),
+  "event with tooltip": (
+    <TimelineProvider>
+      <Wrapper>
+        <TimelineEvent event={queryEvent} />
+      </Wrapper>
+    </TimelineProvider>
   )
 };

--- a/src/panel/pages/timeline/components/TimelineEvent.tsx
+++ b/src/panel/pages/timeline/components/TimelineEvent.tsx
@@ -53,8 +53,6 @@ export const TimelineEvent = ({ event }: { event: ParsedEvent }) => {
     event
   ]);
 
-  console.log(ref.current && ref.current.getBoundingClientRect());
-
   return (
     <Wrapper>
       <Container

--- a/src/panel/pages/timeline/components/TimelineEvent.tsx
+++ b/src/panel/pages/timeline/components/TimelineEvent.tsx
@@ -1,5 +1,8 @@
+import React, { MouseEvent } from "react";
 import styled from "styled-components";
 import { ParsedEvent } from "../../../types";
+import { theme as importedTheme } from "../../../theme";
+import { useTimelineTooltip, Position } from "./TimelineTooltip";
 
 /** Convert parsed event to timeline event type. */
 const getEventType = (event: ParsedEvent) => {
@@ -14,25 +17,40 @@ const getEventType = (event: ParsedEvent) => {
   return "addition";
 };
 
-export const TimelineEvent = styled.div.attrs<{ event: ParsedEvent }>(
-  props => ({
-    "data-type": getEventType(props.event)
-  })
-)<{ event: ParsedEvent }>`
+const COLOR_MAPPING = {
+  addition: importedTheme.green["0"],
+  update: importedTheme.orange["0"],
+  teardown: importedTheme.grey["-1"]
+};
+
+const Container = styled.div`
   border-radius: 50%;
   width: 10px;
   height: 10px;
   border: solid 2px ${props => props.theme.dark["+1"]};
-
-  &[data-type="addition"] {
-    background: ${props => props.theme.green["0"]};
-  }
-
-  &[data-type="update"] {
-    background: ${props => props.theme.orange["0"]};
-  }
-
-  &[data-type="teardown"] {
-    background: ${props => props.theme.grey["-1"]};
-  }
+  background: ${props => props.color};
 `;
+
+const getPosFromRef = (e: MouseEvent): Position => ({
+  x: e.clientX,
+  y: e.clientY
+});
+
+export const TimelineEvent = ({ event }: { event: ParsedEvent }) => {
+  const [render, setPos] = useTimelineTooltip() as [
+    () => JSX.Element | null,
+    React.Dispatch<React.SetStateAction<Position | null>>
+  ];
+  const eventColor = React.useMemo(() => COLOR_MAPPING[getEventType(event)], [
+    event
+  ]);
+  return (
+    <Container
+      color={eventColor}
+      onMouseEnter={e => setPos(getPosFromRef(e))}
+      onMouseLeave={() => setPos(null)}
+    >
+      {render()}
+    </Container>
+  );
+};

--- a/src/panel/pages/timeline/components/TimelineEvent.tsx
+++ b/src/panel/pages/timeline/components/TimelineEvent.tsx
@@ -1,12 +1,10 @@
-import React from "react";
-import styled from "styled-components";
+import React, { FC, useContext, useMemo } from "react";
+import styled, { ThemeContext } from "styled-components";
 import { ParsedEvent } from "../../../types";
-import { theme as importedTheme } from "../../../theme";
-import { useTimelineContext } from "../../../context/Timeline";
-import { TooltipPosition } from "./TimelineTooltip";
+import { useTooltip, TimelineTooltip } from "./TimelineTooltip";
 
 /** Convert parsed event to timeline event type. */
-const getEventType = (event: ParsedEvent) => {
+const getEventName = (event: ParsedEvent) => {
   if (event.type === "teardown") {
     return "teardown";
   }
@@ -18,17 +16,7 @@ const getEventType = (event: ParsedEvent) => {
   return "addition";
 };
 
-const COLOR_MAPPING = {
-  addition: importedTheme.green["0"],
-  update: importedTheme.orange["0"],
-  teardown: importedTheme.grey["-1"]
-};
-
-const Wrapper = styled.div`
-  padding: 50px;
-`;
-
-const Container = styled.div`
+const EventDot = styled.div`
   border-radius: 50%;
   width: 10px;
   height: 10px;
@@ -36,32 +24,31 @@ const Container = styled.div`
   background: ${props => props.color};
 `;
 
-const getPosFromRef = (
-  ref: React.RefObject<HTMLDivElement>
-): TooltipPosition => {
-  const { x, y, width, height } = ref.current!.getBoundingClientRect(); //eslint-disable-line @typescript-eslint/no-non-null-assertion
-  return {
-    x: x + width / 2,
-    y: y + height / 2
-  };
-};
+export const TimelineEvent: FC<{
+  event: ParsedEvent;
+} & JSX.IntrinsicElements["div"]> = ({ event, ...elementProps }) => {
+  const theme = useContext(ThemeContext);
+  const { ref, tooltipProps, isVisible } = useTooltip();
+  const eventName = useMemo(() => getEventName(event), [event]);
 
-export const TimelineEvent = ({ event }: { event: ParsedEvent }) => {
-  const { setTooltipPosition } = useTimelineContext();
-  const ref = React.useRef<HTMLDivElement>(null);
-  const eventColor = React.useMemo(() => COLOR_MAPPING[getEventType(event)], [
-    event
-  ]);
+  const eventColor = React.useMemo(
+    () =>
+      ({
+        addition: theme.green["0"],
+        update: theme.orange["0"],
+        teardown: theme.grey["-1"]
+      }[eventName]),
+    [eventName, theme]
+  );
 
   return (
-    <Wrapper>
-      <Container
-        ref={ref}
-        color={eventColor}
-        onMouseEnter={() => setTooltipPosition(getPosFromRef(ref))}
-        // TODO: triggering too often currently
-        onMouseOut={() => setTooltipPosition(null)}
-      />
-    </Wrapper>
+    <>
+      <EventDot {...elementProps} color={eventColor} ref={ref} />
+      {isVisible && (
+        <TimelineTooltip {...tooltipProps}>
+          {`This is a query ${eventName}`}
+        </TimelineTooltip>
+      )}
+    </>
   );
 };

--- a/src/panel/pages/timeline/components/TimelineRequest.fixture.tsx
+++ b/src/panel/pages/timeline/components/TimelineRequest.fixture.tsx
@@ -9,7 +9,7 @@ import { TimelineRequest } from "./TimelineRequest";
 
 const Wrapper = styled.div`
   display: flex;
-  padding: 10px;
+  padding: 100px;
   background: ${props => props.theme.dark["0"]};
   flex-grow: 1;
 `;

--- a/src/panel/pages/timeline/components/TimelineTooltip.fixture.tsx
+++ b/src/panel/pages/timeline/components/TimelineTooltip.fixture.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { TimelineTooltip, TooltipPosition } from "./TimelineTooltip";
+import { TimelineTooltip, useTooltip } from "./TimelineTooltip";
 
 const Wrapper = styled.div`
   display: flex;
@@ -9,7 +9,29 @@ const Wrapper = styled.div`
   flex-grow: 1;
 `;
 
-const position: TooltipPosition = { x: 50, y: 50 };
+const HoverableItem = () => {
+  const { ref, tooltipProps, isVisible } = useTooltip();
+
+  console.log({ ref, tooltipProps, isVisible });
+
+  return (
+    <>
+      <button
+        style={{
+          position: "absolute",
+          left: 200,
+          top: 200,
+          width: 100,
+          height: 30
+        }}
+        ref={ref}
+      >
+        Hover me!
+      </button>
+      {isVisible && <TimelineTooltip {...tooltipProps}>Hello!</TimelineTooltip>}
+    </>
+  );
+};
 
 export default {
   basic: (
@@ -17,11 +39,9 @@ export default {
       <TimelineTooltip>A network response or cache update</TimelineTooltip>
     </Wrapper>
   ),
-  positioned: (
+  onHover: (
     <Wrapper>
-      <TimelineTooltip position={position}>
-        A network response or cache update
-      </TimelineTooltip>
+      <HoverableItem />
     </Wrapper>
   )
 };

--- a/src/panel/pages/timeline/components/TimelineTooltip.fixture.tsx
+++ b/src/panel/pages/timeline/components/TimelineTooltip.fixture.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { TimelineTooltip } from "./TimelineTooltip";
+import { TimelineTooltip, TooltipPosition } from "./TimelineTooltip";
 
 const Wrapper = styled.div`
   display: flex;
@@ -8,6 +8,8 @@ const Wrapper = styled.div`
   background: ${props => props.theme.dark["0"]};
   flex-grow: 1;
 `;
+
+const position: TooltipPosition = { x: 50, y: 50 };
 
 export default {
   basic: (
@@ -17,7 +19,7 @@ export default {
   ),
   positioned: (
     <Wrapper>
-      <TimelineTooltip pos={{ x: 50, y: 50 }}>
+      <TimelineTooltip position={position}>
         A network response or cache update
       </TimelineTooltip>
     </Wrapper>

--- a/src/panel/pages/timeline/components/TimelineTooltip.fixture.tsx
+++ b/src/panel/pages/timeline/components/TimelineTooltip.fixture.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import styled from "styled-components";
+import { TimelineTooltip } from "./TimelineTooltip";
+
+const Wrapper = styled.div`
+  display: flex;
+  padding: 10px;
+  background: ${props => props.theme.dark["0"]};
+  flex-grow: 1;
+`;
+
+export default {
+  basic: (
+    <Wrapper>
+      <TimelineTooltip>A network response or cache update</TimelineTooltip>
+    </Wrapper>
+  ),
+  positioned: (
+    <Wrapper>
+      <TimelineTooltip pos={{ x: 50, y: 50 }}>
+        A network response or cache update
+      </TimelineTooltip>
+    </Wrapper>
+  )
+};

--- a/src/panel/pages/timeline/components/TimelineTooltip.tsx
+++ b/src/panel/pages/timeline/components/TimelineTooltip.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import styled from "styled-components";
 
 export interface Position {
@@ -27,8 +28,17 @@ export const TimelineTooltip = styled.p<{ pos?: Position }>`
     border-top: 8px solid ${p => p.theme.dark["-2"]};
     border-left: 8px solid transparent;
     border-right: 8px solid transparent;
-    left: 50px;
+    left: 20px;
     top: 100%;
     transform: translate(-50%, 0);
   }
 `;
+
+export const useTimelineTooltip = () => {
+  const [pos, setPos] = React.useState<Position | null>(null);
+
+  const render = React.useCallback(() => {
+    return pos ? <TimelineTooltip pos={pos} /> : null;
+  }, [pos]);
+  return [render, setPos];
+};

--- a/src/panel/pages/timeline/components/TimelineTooltip.tsx
+++ b/src/panel/pages/timeline/components/TimelineTooltip.tsx
@@ -1,3 +1,13 @@
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useMemo,
+  useCallback,
+  MutableRefObject,
+  FC,
+  ComponentProps
+} from "react";
 import styled from "styled-components";
 
 export interface TooltipPosition {
@@ -5,30 +15,117 @@ export interface TooltipPosition {
   y: number;
 }
 
-export const TimelineTooltip = styled.p<{ position?: TooltipPosition }>`
-  background-color: ${p => p.theme.dark["-2"]};
+export const TimelineTooltip: FC<JSX.IntrinsicElements["div"]> = ({
+  children,
+  ...props
+}) => (
+  <div {...props} style={{ paddingBottom: 8, ...props.style }}>
+    <TooltipElement>{children}</TooltipElement>
+  </div>
+);
+
+const TooltipElement = styled.p<{ position?: TooltipPosition }>`
+  position: relative;
+  background-color: ${p => p.theme.dark["+1"]};
   border-radius: 2px;
-  color: ${p => p.theme.grey["+2"]};
-  height: fit-content;
-  left: ${p => p.position && `${p.position.x}px`};
+  color: #fff;
+  font-size: 12px;
   margin: 0;
   padding: 10px 20px;
-  position: absolute;
-  transform: translateX(-50%) translateY(calc(-100% - 8px));
-  /* temp important to get around cosmos style */
-  top: ${p => p.position && `${p.position.y}px`} !important;
 
   &::after {
     content: "";
     display: block;
-    width: 0;
-    height: 0;
     position: absolute;
-    border-top: 8px solid ${p => p.theme.dark["-2"]};
+    border-top: 9px solid ${p => p.theme.dark["+1"]};
     border-left: 6px solid transparent;
     border-right: 6px solid transparent;
-    left: 20px;
+    margin-top: -1px;
+    left: 50%;
     top: 100%;
     transform: translate(-50%, 0);
   }
 `;
+
+export const useTooltip = () => {
+  const ref: MutableRefObject<HTMLElement | null> = useRef<HTMLElement>(null);
+  const [hasRef, setHasRef] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+  const [tooltipProps, setTooltipProps] = useState<
+    ComponentProps<typeof TimelineTooltip>
+  >({});
+
+  const calculateTooltipPosition = useCallback(() => {
+    if (!ref.current) {
+      return;
+    }
+
+    const { x, y, width } = ref.current.getBoundingClientRect(); //eslint-disable-line @typescript-eslint/no-non-null-assertion
+    setTooltipProps({
+      style: {
+        position: "fixed",
+        left: x + width / 2,
+        top: y,
+        transform: `translateX(-50%) translateY(-100%)`
+      }
+    });
+  }, []);
+
+  const handleRef = useCallback(passedRef => {
+    console.log(passedRef);
+    if (passedRef === null) {
+      return;
+    }
+
+    ref.current = passedRef;
+    calculateTooltipPosition();
+    setHasRef(true);
+  }, []);
+
+  // Update position on resize
+  useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+
+    const mObserver = new MutationObserver(calculateTooltipPosition);
+    const rObserver = new ResizeObserver(calculateTooltipPosition);
+    mObserver.observe(ref.current, {
+      attributes: true,
+      childList: true
+    });
+    rObserver.observe(ref.current);
+    return () => {
+      mObserver.disconnect();
+      rObserver.disconnect();
+    };
+  }, [hasRef]);
+
+  // Set visible on mouse enter
+  useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+
+    const setVisible = () => setIsVisible(true);
+    const setInvisible = () => setIsVisible(false);
+    ref.current.addEventListener("mouseenter", setVisible);
+    ref.current.addEventListener("mouseleave", setInvisible);
+    return () => {
+      if (!ref.current) {
+        return;
+      }
+
+      ref.current.removeEventListener("mouseenter", setVisible);
+      ref.current.removeEventListener("mouseleave", setInvisible);
+    };
+  }, [hasRef]);
+
+  console.log({ ref: handleRef, tooltipProps, isVisible });
+
+  return useMemo(() => ({ ref: handleRef, tooltipProps, isVisible }), [
+    handleRef,
+    tooltipProps,
+    isVisible
+  ]);
+};

--- a/src/panel/pages/timeline/components/TimelineTooltip.tsx
+++ b/src/panel/pages/timeline/components/TimelineTooltip.tsx
@@ -1,23 +1,22 @@
-import React from "react";
 import styled from "styled-components";
 
-export interface Position {
+export interface TooltipPosition {
   x: number;
   y: number;
 }
 
-export const TimelineTooltip = styled.p<{ pos?: Position }>`
+export const TimelineTooltip = styled.p<{ position?: TooltipPosition }>`
   background-color: ${p => p.theme.dark["-2"]};
   border-radius: 2px;
-
   color: ${p => p.theme.grey["+2"]};
-
-  left: ${p => p.pos && `${p.pos.x}px`};
-  top: ${p => p.pos && `${p.pos.y}px`};
-
   height: fit-content;
+  left: ${p => p.position && `${p.position.x}px`};
+  margin: 0;
   padding: 10px 20px;
   position: absolute;
+  transform: translateX(-50%) translateY(calc(-100% - 8px));
+  /* temp important to get around cosmos style */
+  top: ${p => p.position && `${p.position.y}px`} !important;
 
   &::after {
     content: "";
@@ -26,19 +25,10 @@ export const TimelineTooltip = styled.p<{ pos?: Position }>`
     height: 0;
     position: absolute;
     border-top: 8px solid ${p => p.theme.dark["-2"]};
-    border-left: 8px solid transparent;
-    border-right: 8px solid transparent;
+    border-left: 6px solid transparent;
+    border-right: 6px solid transparent;
     left: 20px;
     top: 100%;
     transform: translate(-50%, 0);
   }
 `;
-
-export const useTimelineTooltip = () => {
-  const [pos, setPos] = React.useState<Position | null>(null);
-
-  const render = React.useCallback(() => {
-    return pos ? <TimelineTooltip pos={pos} /> : null;
-  }, [pos]);
-  return [render, setPos];
-};

--- a/src/panel/pages/timeline/components/TimelineTooltip.tsx
+++ b/src/panel/pages/timeline/components/TimelineTooltip.tsx
@@ -1,0 +1,34 @@
+import styled from "styled-components";
+
+export interface Position {
+  x: number;
+  y: number;
+}
+
+export const TimelineTooltip = styled.p<{ pos?: Position }>`
+  background-color: ${p => p.theme.dark["-2"]};
+  border-radius: 2px;
+
+  color: ${p => p.theme.grey["+2"]};
+
+  left: ${p => p.pos && `${p.pos.x}px`};
+  top: ${p => p.pos && `${p.pos.y}px`};
+
+  height: fit-content;
+  padding: 10px 20px;
+  position: absolute;
+
+  &::after {
+    content: "";
+    display: block;
+    width: 0;
+    height: 0;
+    position: absolute;
+    border-top: 8px solid ${p => p.theme.dark["-2"]};
+    border-left: 8px solid transparent;
+    border-right: 8px solid transparent;
+    left: 50px;
+    top: 100%;
+    transform: translate(-50%, 0);
+  }
+`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
-    "lib": ["dom"],
+    "lib": ["dom", "esnext"],
     "jsx": "react",
     "strict": true,
     "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,6 +1160,18 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/d3-scale@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-2.2.0.tgz#e5987a2857365823eb26ed5eb21bc566c4dcf1c0"
+  integrity sha512-oQFanN0/PiR2oySHfj+zAAkK1/p4LD32Nt1TMVmzk+bYHk7vgIg/iTXQWitp1cIkDw4LMdcgvO63wL+mNs47YA==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-time@*":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-1.0.10.tgz#d338c7feac93a98a32aac875d1100f92c7b61f4f"
+  integrity sha512-aKf62rRQafDQmSiv1NylKhIMmznsjRN+MnXRXTqHoqm0U/UZzVpdrtRnSIfdiLS616OuC1soYeX1dBg2n1u8Xw==
+
 "@types/enzyme-adapter-react-16@^1.0.5":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.6.tgz#8aca7ae2fd6c7137d869b6616e696d21bb8b0cec"
@@ -3615,6 +3627,51 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
+
+"d3-array@1.2.0 - 2":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
+  integrity sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw==
+
+d3-color@1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.0.tgz#89c45a995ed773b13314f06460df26d60ba0ecaf"
+  integrity sha512-TzNPeJy2+iEepfiL92LAAB7fvnp/dV2YwANPVHdDWmYMm23qIJBYww3qT8I8C1wXrmrg4UWs7BKc2tKIgyjzHg==
+
+d3-format@1:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.3.tgz#4e8eb4dff3fdcb891a8489ec6e698601c41b96f1"
+  integrity sha512-mm/nE2Y9HgGyjP+rKIekeITVgBtX97o1nrvHCWX8F/yBYyevUTvu9vb5pUnKwrcSw7o7GuwMOWjS9gFDs4O+uQ==
+
+d3-interpolate@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
+  integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
+  dependencies:
+    d3-color "1"
+
+d3-scale@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-3.2.1.tgz#da1684adce7261b4bc7a76fe193d887f0e909e69"
+  integrity sha512-huz5byJO/6MPpz6Q8d4lg7GgSpTjIZW/l+1MQkzKfu2u8P6hjaXaStOpmyrD6ymKoW87d2QVFCKvSjLwjzx/rA==
+  dependencies:
+    d3-array "1.2.0 - 2"
+    d3-format "1"
+    d3-interpolate "^1.2.0"
+    d3-time "1"
+    d3-time-format "2"
+
+d3-time-format@2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.2.3.tgz#0c9a12ee28342b2037e5ea1cf0b9eb4dd75f29cb"
+  integrity sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==
+  dependencies:
+    d3-time "1"
+
+d3-time@1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
+  integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
 
 d@1, d@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1373,6 +1373,11 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/resize-observer-browser@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@types/resize-observer-browser/-/resize-observer-browser-0.1.3.tgz#5cca2445e6fc34a380760bd6ef8c492863469c47"
+  integrity sha512-3tGjLIDH8L57fWOfC7NVn/BbGQD7pXwbkk2+8Z4hK/S7kOIv1MUN4nkKjfx0qg4ctkukjzp3Bgr/Z+Hq5ZQZTQ==
+
 "@types/source-list-map@*":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"


### PR DESCRIPTION
## Changes

- adds \<TimelineTooltip /> and associated `useTooltip` hook
- tooltip is displayed/hidden by by setting the ref on the desired element to be the one exposed by `useTooltip`
- adds tracks the position of the tooltip via mouse events and via MutationObserver/ResizeObserver