### PR TITLE
Fix crash on undefined argument value.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ yarn-error.log
 .DS_Store
 web-ext-artifacts
 __diff_output__
+.idea

--- a/src/panel/pages/explorer/components/Arguments.spec.tsx
+++ b/src/panel/pages/explorer/components/Arguments.spec.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { Arguments } from "./Arguments"
+
+const props = {
+  args: {
+    string: "abc",
+    number: 7,
+    object: {
+      string: "def"
+    },
+    //JSON.stringify type definition is somewhat problematic.
+    // JSON.stringify(null) //"null"
+    // JSON.stringify(null) //undefined
+    // But JSON.stringify return type is string.
+    // Therefore, it will cause any TS null|undefined checks to actually fail at runtime.
+    // THe Highlight component will crash if it ever gets a null|undefined code string.
+    // Both cases have to be explicitly tested.
+    nullable: null,
+    undefinable: undefined
+  }
+}
+describe("on mount", () => {
+  it("matches snapshot", () => {
+    const wrapper = shallow(<Arguments {...props}/>);
+    expect(wrapper).toMatchSnapshot();
+  })
+})

--- a/src/panel/pages/explorer/components/Arguments.spec.tsx
+++ b/src/panel/pages/explorer/components/Arguments.spec.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { shallow } from "enzyme";
-import { Arguments } from "./Arguments"
+import { Arguments } from "./Arguments";
 
 const props = {
   args: {
     string: "abc",
     number: 7,
     object: {
-      string: "def"
+      string: "def",
     },
     //JSON.stringify type definition is somewhat problematic.
     // JSON.stringify(null) //"null"
@@ -17,12 +17,12 @@ const props = {
     // THe Highlight component will crash if it ever gets a null|undefined code string.
     // Both cases have to be explicitly tested.
     nullable: null,
-    undefinable: undefined
-  }
-}
+    undefinable: undefined,
+  },
+};
 describe("on mount", () => {
   it("matches snapshot", () => {
-    const wrapper = shallow(<Arguments {...props}/>);
+    const wrapper = shallow(<Arguments {...props} />);
     expect(wrapper).toMatchSnapshot();
-  })
-})
+  });
+});

--- a/src/panel/pages/explorer/components/Arguments.tsx
+++ b/src/panel/pages/explorer/components/Arguments.tsx
@@ -9,19 +9,18 @@ export const Arguments: FC<{
   if (!args) {
     return null;
   }
-
   const entries = useMemo(() => Object.entries(args), [args]);
-
   return (
     <ArgumentText>
       (
-      {entries.map(([key, value], index) => (
-        <Fragment key={key}>
-          {`${key}: `}
-          <InlineCodeHighlight code={JSON.stringify(value)} language="json" />
-          {index !== entries.length - 1 && ", "}
-        </Fragment>
-      ))}
+      {entries
+        .map(([key, value], index) => (
+            <Fragment key={key}>
+              {`${key}: `}
+              <InlineCodeHighlight code={JSON.stringify(value) || "undefined"} language="json"/>
+              {index !== entries.length - 1 && ", "}
+            </Fragment>
+          ))}
       )
     </ArgumentText>
   );

--- a/src/panel/pages/explorer/components/Arguments.tsx
+++ b/src/panel/pages/explorer/components/Arguments.tsx
@@ -18,7 +18,10 @@ export const Arguments: FC<{
       {entries.map(([key, value], index) => (
         <Fragment key={key}>
           {`${key}: `}
-          <InlineCodeHighlight code={JSON.stringify(value) || "undefined" } language="json" />
+          <InlineCodeHighlight
+            code={JSON.stringify(value) || "undefined"}
+            language="json"
+          />
           {index !== entries.length - 1 && ", "}
         </Fragment>
       ))}

--- a/src/panel/pages/explorer/components/Arguments.tsx
+++ b/src/panel/pages/explorer/components/Arguments.tsx
@@ -9,18 +9,19 @@ export const Arguments: FC<{
   if (!args) {
     return null;
   }
+
   const entries = useMemo(() => Object.entries(args), [args]);
+
   return (
     <ArgumentText>
       (
-      {entries
-        .map(([key, value], index) => (
-            <Fragment key={key}>
-              {`${key}: `}
-              <InlineCodeHighlight code={JSON.stringify(value) || "undefined"} language="json"/>
-              {index !== entries.length - 1 && ", "}
-            </Fragment>
-          ))}
+      {entries.map(([key, value], index) => (
+        <Fragment key={key}>
+          {`${key}: `}
+          <InlineCodeHighlight code={JSON.stringify(value) || "undefined" } language="json" />
+          {index !== entries.length - 1 && ", "}
+        </Fragment>
+      ))}
       )
     </ArgumentText>
   );

--- a/src/panel/pages/explorer/components/__snapshots__/Arguments.spec.tsx.snap
+++ b/src/panel/pages/explorer/components/__snapshots__/Arguments.spec.tsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`on mount matches snapshot 1`] = `
+<ArgumentText>
+  (
+  string: 
+  <Memo(InlineCodeHighlightMemo)
+    code="\\"abc\\""
+    language="json"
+  />
+  , 
+  number: 
+  <Memo(InlineCodeHighlightMemo)
+    code="7"
+    language="json"
+  />
+  , 
+  object: 
+  <Memo(InlineCodeHighlightMemo)
+    code="{\\"string\\":\\"def\\"}"
+    language="json"
+  />
+  , 
+  nullable: 
+  <Memo(InlineCodeHighlightMemo)
+    code="null"
+    language="json"
+  />
+  , 
+  undefinable: 
+  <Memo(InlineCodeHighlightMemo)
+    code="undefined"
+    language="json"
+  />
+  )
+</ArgumentText>
+`;


### PR DESCRIPTION
I have a query with an optional input variable, like

```graphsl
query aQuery(
  $tenant: [String!]!
  $input: Input!
  $after: String
) {
```

This results in the tab crashing after that query is executed in my app.

```
Main._createAppUI: 18.40673828125ms
MainImpl.js:5 Main._showAppUI: 7.31396484375ms
MainImpl.js:5 Main._initializeTarget: 7.925048828125ms
MainImpl.js:5 Main._lateInitialization: 3.051025390625ms
panel.js:2 TypeError: Cannot read property 'length' of undefined
    at Object.matchGrammar (panel.js:2)
    at Object.tokenize (panel.js:2)
    at t.render (panel.js:2)
    at Do (panel.js:2)
    at jo (panel.js:2)
    at vc (panel.js:2)
    at sl (panel.js:2)
    at cl (panel.js:2)
    at Jc (panel.js:2)
    at panel.js:2
chrome-extension://m…el.html#/explorer:1 Error in event handler: TypeError: Cannot read property 'length' of undefined
    at Object.matchGrammar (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1616658)
    at Object.tokenize (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1617438)
    at t.render (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1678169)
    at Do (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1321152)
    at jo (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1320947)
    at vc (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1356746)
    at sl (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1347993)
    at cl (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1347918)
    at Jc (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1344948)
    at chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1296590
chrome-extension://m…el.html#/explorer:1 Error in event handler: TypeError: Cannot read property 'length' of undefined
    at Object.matchGrammar (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1616658)
    at Object.tokenize (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1617438)
    at t.render (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1678169)
    at Do (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1321152)
    at jo (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1320947)
    at vc (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1356746)
    at sl (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1347993)
    at cl (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1347918)
    at Jc (chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1344948)
    at chrome-extension://mcfphkbpmkbeofnkjehahlmidmceblmm/panel.js:2:1296590
```

![image](https://user-images.githubusercontent.com/5818899/80738132-c3714600-8ad1-11ea-8a7c-181f265a7247.png)

The root cause is `JSON.stringify` has a bad type definition.  It will return undefined for an undefined input.  So when it tries to render the `$after` variable, it crashes.

The fix is fairly simple and already applied in ListItem.tsx, so I updated Arguments.tsx and added a test for the various argument types.