### PR TITLE
 Inject extension files into all frames in a tab

### DIFF
--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -18,6 +18,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
+      "all_frames": true,
       "js": ["content_script.js"],
       "run_at": "document_start"
     }


### PR DESCRIPTION
## About

- add `all_frames` prop to manifest to support urql instances inside iframes rather than just the topmost frame in a tab

Closes #280 

## Outstanding questions

- What would happen if there were multiple instances of urql running within a page? Would we want to support that? At the moment the extension will just pick up the first identified instance 