### PR TITLE
Add highlight to selected event

### DIFF
--- a/src/panel/pages/events/components/TimelineDuration.tsx
+++ b/src/panel/pages/events/components/TimelineDuration.tsx
@@ -9,9 +9,12 @@ export const TimelineAliveDuration = styled.div`
 
 type NetworkState = "fetching" | "success" | "error";
 
-export const NetworkDuration = styled.div`
+export const NetworkDuration = styled.div<{ isSelected?: boolean }>`
   cursor: pointer;
   height: 10px;
+
+  outline: ${({ isSelected, theme }) =>
+    isSelected ? `${theme.grey["-7"]} solid 3px` : "none"};
 
   &[data-state="fetching"] {
     background: ${(props) => props.theme.blue["-1"]};
@@ -27,7 +30,9 @@ export const NetworkDuration = styled.div`
 `;
 
 export const TimelineNetworkDuration: FC<
-  { state: NetworkState } & ComponentProps<typeof NetworkDuration>
+  { state: NetworkState; isSelected?: boolean } & ComponentProps<
+    typeof NetworkDuration
+  >
 > = ({ state, ...props }) => {
   const { ref, tooltipProps, isVisible } = useTooltip();
 

--- a/src/panel/pages/events/components/TimelineRow.tsx
+++ b/src/panel/pages/events/components/TimelineRow.tsx
@@ -11,7 +11,13 @@ import {
 export const TimelineRow: FC<
   { events: DebugEvent[] } & ComponentProps<typeof Container>
 > = ({ events, ...props }) => {
-  const { container, scale, setSelectedEvent, filter } = useTimelineContext();
+  const {
+    container,
+    scale,
+    setSelectedEvent,
+    selectedEvent,
+    filter,
+  } = useTimelineContext();
 
   const eventElements = useMemo(
     () =>
@@ -122,6 +128,7 @@ export const TimelineRow: FC<
             <TimelineNetworkDuration
               key={`n-${p.elements.length}`}
               state="success"
+              isSelected={e.timestamp === selectedEvent?.timestamp}
               style={{
                 position: "absolute",
                 left: scale(p.start.timestamp),
@@ -141,6 +148,7 @@ export const TimelineRow: FC<
             ...p.elements,
             <TimelineNetworkDuration
               key={`n-${p.elements.length}`}
+              isSelected={e.timestamp === selectedEvent?.timestamp}
               state="error"
               style={{
                 position: "absolute",


### PR DESCRIPTION
## What?
This commit adds an `outline` css property when an event is selected.

## Why?
When inspecting events, it is not always obvious which event you clicked on. Hopefully this change will help!

![urql-gif](https://user-images.githubusercontent.com/12150276/90514850-a6808180-e159-11ea-9985-da6d35aaae0c.gif)

Closes #273 