### PR TITLE
Fix typescript and add type check step to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,14 @@ jobs:
       - *restore_node_modules_cache
       - run: yarn run lint:prettier
 
+  type check:
+    <<: *node_env
+    <<: *ramdisk
+    steps:
+      - checkout
+      - *restore_node_modules_cache
+      - run: yarn run type-check
+
   test:
     <<: *node_env
     <<: *ramdisk

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "visual-regression": "./scripts/regression.sh",
     "visual-regression:exec": "jest --no-cache visual-regression --runInBand",
     "webpack:electron": "webpack --config webpack/webpack.electron.config.js",
-    "webpack:extension": "webpack --config webpack/webpack.extension.config.js"
+    "webpack:extension": "webpack --config webpack/webpack.extension.config.js",
+    "type-check": "yarn tsc"
   },
   "bin": "./scripts/cli.js",
   "engines": {

--- a/src/panel/App.test.tsx
+++ b/src/panel/App.test.tsx
@@ -1,6 +1,6 @@
 jest.mock("./context/Devtools.tsx", () => {
   return {
-    ...jest.requireActual("./context/Devtools.tsx"),
+    ...(jest.requireActual("./context/Devtools.tsx") as {}),
     useDevtoolsContext: jest.fn(),
   };
 });

--- a/src/panel/components/Pane.tsx
+++ b/src/panel/components/Pane.tsx
@@ -12,7 +12,8 @@ import { useOrientationWatcher } from "../hooks";
 
 interface OverrideProps {
   forcedOrientation?: { isPortrait: boolean };
-  initSize: { x: number; y: number };
+  initSize?: { x: number; y: number };
+  "data-snapshot"?: boolean;
 }
 
 const PaneRoot: FC<ComponentProps<typeof PaneContainer> & OverrideProps> = ({

--- a/src/panel/pages/request/components/Query.tsx
+++ b/src/panel/pages/request/components/Query.tsx
@@ -10,7 +10,7 @@ import "codemirror/addon/lint/lint.css";
 import "codemirror-graphql/lint";
 import "codemirror-graphql/hint";
 import "codemirror-graphql/mode";
-import CodeMirror, { ShowHintOptions } from "codemirror";
+import CodeMirror, { ShowHintOptions, LintStateOptions } from "codemirror";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { useRequest } from "../../../context";
@@ -41,7 +41,7 @@ export const Query = () => {
     }
 
     // TODO!: Update types
-    codemirror.setOption("lint", { schema });
+    codemirror.setOption("lint", ({ schema } as unknown) as LintStateOptions);
     codemirror.setOption("hintOptions", ({
       schema,
     } as unknown) as ShowHintOptions);

--- a/src/panel/pages/request/components/Stack.fixture.tsx
+++ b/src/panel/pages/request/components/Stack.fixture.tsx
@@ -1,13 +1,8 @@
 import React from "react";
-import { schema } from "./Schema.fixture";
 import { Stack } from "./Stack";
 
-const typeMap = schema.getTypeMap();
-const stackMock = [typeMap["Reply"]];
 const setTypeMock = (type: any) => console.log(type);
 
 export default {
-  basic: (
-    <Stack stack={stackMock} setStack={setTypeMock} setType={setTypeMock} />
-  ),
+  basic: <Stack setStack={setTypeMock} setType={setTypeMock} />,
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,9 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "downlevelIteration": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "skipLibCheck": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "src/**/visual-regression.test.ts"]


### PR DESCRIPTION
There were 200+ typescript errors in the codebase.

The vast majority of the errors (~150) were caused by type errors in our libraries. To fix this I've needed to set `skipLibCheck: true` in `tsconfig`.

The rest were all in our domain, which are now fixed.

To prevent errors from creeping back in, I've also added the type check step to CI.