### PR TITLE
Run typescript in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,6 +187,12 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - type check:
+          requires:
+            - install
+          filters:
+            tags:
+              only: /.*/
       - test:
           requires:
             - install


### PR DESCRIPTION
I didn't fully configure the circle ci config to run the typescript step in #290.

This PR _should_ fix that.