### PR TITLE
Handle empty data prop in Explorer

### DIFF
--- a/src/panel/context/Explorer/ast/index.test.tsx
+++ b/src/panel/context/Explorer/ast/index.test.tsx
@@ -1310,3 +1310,36 @@ it("embedded object on entity", () => {
     }
   `);
 });
+
+it("Handles empty data", () => {
+  expectCorrectOutput({
+    query: gql`
+      {
+        __typename
+        int
+      }
+    `,
+    data: null,
+  }).toMatchInlineSnapshot(`
+    Object {
+      "__typename": Object {
+        "_id": "[nanoid]",
+        "_owner": Object {},
+        "args": undefined,
+        "cacheOutcome": "hit",
+        "key": "__typename",
+        "name": "__typename",
+        "value": undefined,
+      },
+      "int": Object {
+        "_id": "[nanoid]",
+        "_owner": Object {},
+        "args": undefined,
+        "cacheOutcome": "hit",
+        "key": "int",
+        "name": "int",
+        "value": undefined,
+      },
+    }
+  `);
+});

--- a/src/panel/context/Explorer/ast/index.ts
+++ b/src/panel/context/Explorer/ast/index.ts
@@ -28,7 +28,7 @@ export type ParsedNodeMap = Record<string, ParsedFieldNode>;
 
 interface HandleResponseArgs {
   operation: Operation;
-  data: OperationResult["data"];
+  data?: OperationResult["data"];
   parsedNodes?: ParsedNodeMap;
 }
 
@@ -86,7 +86,7 @@ interface CopyFromDataArgs {
   cacheOutcome: OperationDebugMeta["cacheOutcome"];
   parsedNodes: ParsedNodeMap;
   selections: readonly SelectionNode[];
-  data: OperationResult["data"];
+  data?: OperationResult["data"];
   owner: {};
 }
 
@@ -130,7 +130,7 @@ const parseNodes = (copyArgs: CopyFromDataArgs): ParsedNodeMap => {
     const args = getFieldArguments(selectionNode, variables);
     const key = getFieldKey(name, args);
     const value =
-      data[
+      data?.[
         selectionNode.alias !== undefined
           ? selectionNode.alias.value
           : selectionNode.name.value


### PR DESCRIPTION
Closes #293

Ideally, Typescript would've caught this, however the type of `Data`
from urql itself gives `any` - so no help here.

I've added the `?` attribute to the type anyway for documentation
purposes.

Also added a test case for when the `data` prop is empty.
