### PR TITLE
Fix electron require

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
     "@typescript-eslint/no-explicit-any": 0,
     "@typescript-eslint/no-use-before-define": 0,
     "@typescript-eslint/prefer-interface": 0,
+    "@typescript-eslint/no-var-requires": 0,
     "import/named": 0,
     "react/prop-types": 0,
     "react/no-children-prop": 0

--- a/src/panel/util/Connection.ts
+++ b/src/panel/util/Connection.ts
@@ -1,5 +1,4 @@
 import { ExchangeMessage, DevtoolsMessage } from "@urql/devtools";
-import { ipcRenderer } from "electron";
 import { DevtoolsPanelConnectionName } from "../../types";
 
 export interface ConnectionType {
@@ -22,6 +21,8 @@ export const createConnection = (): ConnectionType => {
   }
 
   let listeners: Array<(msg: ExchangeMessage | DevtoolsMessage) => void> = [];
+  const ipcRenderer = require("electron")
+    .ipcRenderer as import("electron").IpcRenderer;
 
   ipcRenderer.on("message", (_event, message) =>
     listeners.forEach((l) => l(message))

--- a/src/panel/util/openExternalUrl.ts
+++ b/src/panel/util/openExternalUrl.ts
@@ -1,9 +1,8 @@
-import { shell } from "electron";
-
 export const openExternalUrl = (url: string): Window | null | undefined => {
   if (process.env.BUILD_ENV === "extension") {
     return window.open(url, "_blank");
   }
 
+  const shell = require("electron").shell as import("electron").Shell;
   shell.openExternal(url);
 };


### PR DESCRIPTION
Turns out that using `import` from electron causes the error

> fs.existsSync is not a function

when running `yarn cosmos`.

Fix is to use `require` instead of `import`.