### PR TITLE
Default to watch mode for visual regression

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,8 +38,10 @@ With a fixture environment, you can:
 
 Make sure to run the following command after making any visual changes/additions to fixtures
 
+> Note: Check the diff output in `src/panel/__image_snapshots__/__diff_output__` before updating snapshots
+
 ```
-yarn visual-regression -u
+yarn visual-regression
 ```
 
 ### Shallow environment (panel/extension/electron)

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint:prettier": "prettier -c .",
     "start": "electron dist/electron/main.js",
     "test": "jest --testPathIgnorePatterns visual-regression",
-    "visual-regression": "./scripts/regression.sh",
+    "visual-regression": "./scripts/regression.sh --watch",
     "visual-regression:exec": "jest --no-cache visual-regression --runInBand",
     "webpack:electron": "webpack --config webpack/webpack.electron.config.js",
     "webpack:extension": "webpack --config webpack/webpack.extension.config.js",


### PR DESCRIPTION
## About

Minor DX improvement.

Running `yarn visual-regression -u` would update snapshots without first checking diffs which is probably not a great idea 😅 