### PR TITLE
fix: Add new issue templates for electron and extension apps

### DIFF
--- a/src/panel/pages/error/ErrorBoundary.tsx
+++ b/src/panel/pages/error/ErrorBoundary.tsx
@@ -61,10 +61,6 @@ export class ErrorBoundary extends Component<
 const generateErrorTemplate = (err: Error) => {
   if (process.env.BUILD_ENV === "extension") {
     return `
-  | name                           | about                                                              | title | labels | assignees |
-  | ------------------------------ | ------------------------------------------------------------------ | ----- | ------ | --------- |
-  | Bug report (browser extension) | Create a bug report for the browser extension version of devtools. |       | Bug    |           |
-
   # About
     
   <!-- Replace the below description with a brief summary -->
@@ -93,7 +89,7 @@ const generateErrorTemplate = (err: Error) => {
   
   - Extension shows message "Waiting for exchange"
   
-    ## Stack trace
+  ## Stack trace
   
   \`\`\`
   ${err.stack}
@@ -111,10 +107,6 @@ const generateErrorTemplate = (err: Error) => {
   }
   // Electron error template
   return `
-  | name                    | about                                                              | title | labels        | assignees |
-  | ----------------------- | ------------------------------------------------------------------ | ----- | ------------- | --------- |
-  | Bug report (standalone) | Create a bug report for the native/standalone version of devtools. |       | Bug, Electron |           |
-  
   # About
   
   <!-- Replace the below description with a brief summary -->
@@ -168,6 +160,7 @@ const createIssueUrl = (err: Error) => {
   const uri = `https://github.com/FormidableLabs/urql-devtools/issues/new`;
   const params = new URLSearchParams({
     title: `[Runtime error]: ${err.message || "Unknown error"}`,
+    labels: process.env.BUILD_ENV === "extension" ? "Bug" : "Bug,Electron",
     body: generateErrorTemplate(err),
   });
 

--- a/src/panel/pages/error/ErrorBoundary.tsx
+++ b/src/panel/pages/error/ErrorBoundary.tsx
@@ -58,28 +58,117 @@ export class ErrorBoundary extends Component<
   }
 }
 
+const generateErrorTemplate = (err: Error) => {
+  if (process.env.BUILD_ENV === "extension") {
+    return `
+  | name                           | about                                                              | title | labels | assignees |
+  | ------------------------------ | ------------------------------------------------------------------ | ----- | ------ | --------- |
+  | Bug report (browser extension) | Create a bug report for the browser extension version of devtools. |       | Bug    |           |
+
+  # About
+    
+  <!-- Replace the below description with a brief summary -->
+    
+  Devtools does not detect a running instance of urql.
+  
+  # Reproduction
+  
+  <!-- Replace the below steps with your reproduction. -->
+  
+  1.  Clone [this example](https://github.com/FormidableLabs/urql/tree/main/packages/react-urql/examples/1-getting-started) project
+  2.  Run \`yarn install\`
+  3.  Run \`yarn start\`
+  4.  Open chrome and navigate to [http://localhost:8080](http://localhost:8080)
+  5.  Open the urql devtools panel
+  
+  ## Expected result
+  
+  <!-- Tell us what you expected. -->
+  
+  - Extension detects app
+  
+  ## Actual result
+  
+  <!-- Tell us what actually happened. -->
+  
+  - Extension shows message "Waiting for exchange"
+  
+    ## Stack trace
+  
+  \`\`\`
+  ${err.stack}
+  \`\`\`
+  
+  # Additional info
+  
+  | environment    | version   |
+  | -------------- | --------- |
+  | browser        | Chrome 69 |
+  | urql           | 0.0.0     |
+  | urql devtools  | 0.0.0     |
+  | @urql/devtools | 0.0.0     |
+    `;
+  }
+  // Electron error template
+  return `
+  | name                    | about                                                              | title | labels        | assignees |
+  | ----------------------- | ------------------------------------------------------------------ | ----- | ------------- | --------- |
+  | Bug report (standalone) | Create a bug report for the native/standalone version of devtools. |       | Bug, Electron |           |
+  
+  # About
+  
+  <!-- Replace the below description with a brief summary -->
+  
+  Devtools is unresponsive when using on an Android device with expo.
+  
+  # Reproduction
+  
+  <!-- Replace the below steps with your reproduction. -->
+  
+  1.  Clone [this example](https://github.com/kadikraman/UrqlTest) react native project
+  2.  Plug in Android phone via USB
+  3.  Run \`yarn install\`
+  4.  Run \`yarn start\`
+  5.  Open devtools using npx \`npx urql-devtools\`
+    
+  ## Expected result
+  
+  <!-- Tell us what you expected. -->
+  
+  - App opens on Android phone
+  - Urql Devtools opens in standalone window
+  - Urql devtools detects app
+  
+  ## Actual result
+  
+  <!-- Tell us what actually happened. -->
+  
+  - App opens on Android phone
+  - Urql devtools opens in standalone window
+  - Urql devtools stays on "waiting for exchange" notice  
+  ## Stack trace
+  
+  \`\`\`
+  ${err.stack}
+  \`\`\`
+  
+  # Additional info
+  
+  | environment    | version        |
+  | -------------- | -------------- |
+  | os             | Macbuntu 20.04 |
+  | node           | 0.0.0          |
+  | urql           | 0.0.0          |
+  | urql-devtools  | 0.0.0          |
+  | @urql/devtools | 0.0.0          |
+  `;
+};
+
 const createIssueUrl = (err: Error) => {
   const uri = `https://github.com/FormidableLabs/urql-devtools/issues/new`;
   const params = new URLSearchParams({
     title: `[Runtime error]: ${err.message || "Unknown error"}`,
-    body: `
-## About
-A runtime error occurred.
-
-## Reproduction
-
-<!-- Enter steps taken to reproduce the error. -->
-
-## Additional info
-
-<!-- Any additional info that may be useful. -->
-
-## Stack trace
-
-\`\`\`
-${err.stack}
-\`\`\`
-  `,
+    body: generateErrorTemplate(err),
   });
 
   return `${uri}?${params}`;


### PR DESCRIPTION
Issue: https://github.com/FormidableLabs/urql-devtools/issues/340

Extension template: 
![image](https://user-images.githubusercontent.com/12056467/114856992-6c52a700-9df0-11eb-8a31-527bf39cbfcb.png)


Electron template:
![image](https://user-images.githubusercontent.com/12056467/114857382-dc612d00-9df0-11eb-849f-9a8600a2a2f1.png)

