### PR TITLE
fix: reset code snippet when try to append a new code

### DIFF
--- a/src/panel/components/CodeHighlight.tsx
+++ b/src/panel/components/CodeHighlight.tsx
@@ -46,9 +46,12 @@ export const CodeHighlight: FC<
       // Create new child node with text
       const child = document.createElement("code");
       child.textContent = code;
-      ref.firstChild
-        ? ref.replaceChild(child, ref.firstChild)
-        : ref.appendChild(child);
+
+      if (ref.hasChildNodes()) {
+        ref.innerHTML = "";
+      }
+
+      ref.appendChild(child);
       // Run prism on element (in web worker/async)
       // when code is a chonker
       Prism.highlightElement(ref, code.length > 600);

--- a/src/panel/pages/events/components/TimelineSourceIcon.tsx
+++ b/src/panel/pages/events/components/TimelineSourceIcon.tsx
@@ -14,7 +14,7 @@ export const TimelineSourceIcon = styled.div<{
   transition: background-color 150ms ease-out;
 
   :before {
-    content: "${({ kind }) => kind && kind[0].toUpperCase()}";
+    content: "${({ kind }) => kind[0].toUpperCase()}";
   }
 
   &:hover {

--- a/src/panel/pages/events/components/TimelineSourceIcon.tsx
+++ b/src/panel/pages/events/components/TimelineSourceIcon.tsx
@@ -14,7 +14,7 @@ export const TimelineSourceIcon = styled.div<{
   transition: background-color 150ms ease-out;
 
   :before {
-    content: "${({ kind }) => kind[0].toUpperCase()}";
+    content: "${({ kind }) => kind && kind[0].toUpperCase()}";
   }
 
   &:hover {


### PR DESCRIPTION
The solution: Clean the code section before appending new clicked query. We first check if there are some child nodes and if there are, we remove them and append the new code. It's strange that there are methods for getting firstChild, all children or parent element, but there is no method for cleaning html code inside the node. 

Root cause: The main issue was that we are replace only the first child, which is one of many inside the node. 

Issue: https://github.com/FormidableLabs/urql-devtools/issues/351

Video after the fix: 

https://user-images.githubusercontent.com/12056467/115618244-1b184b00-a2fb-11eb-89ec-5642f24bd387.mov

