### PR TITLE
chore: Update Electron to support Apple Silicon (M1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     ]
   },
   "dependencies": {
-    "electron": "^9.0.4",
+    "electron": "^13.1.5",
     "prismjs": "^1.21.0",
     "ws": "^7.3.1"
   },

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -49,6 +49,7 @@ const createWindow = () => {
     height: 600,
     webPreferences: {
       nodeIntegration: true,
+      contextIsolation: false
     },
   });
   windows = [...windows, win];

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -49,7 +49,7 @@ const createWindow = () => {
     height: 600,
     webPreferences: {
       nodeIntegration: true,
-      contextIsolation: false
+      contextIsolation: false,
     },
   });
   windows = [...windows, win];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2009,10 +2009,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.11.tgz#61d4886e2424da73b7b25547f59fdcb534c165a3"
   integrity sha512-lCvvI24L21ZVeIiyIUHZ5Oflv1hhHQ5E1S25IRlKIXaRkVgmXpJMI3wUJkmym2bTbCe+WoIibQnMVAU3FguaOg==
 
-"@types/node@^12.0.12":
-  version "12.12.44"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.44.tgz#0d400a1453adcb359b133acceae4dd8bb0e0a159"
-  integrity sha512-jM6QVv0Sm5d3nW+nUD5jSzPcO6oPqboitSNcwgBay9hifVq/Rauq1PYnROnsmuw45JMBiTnsPAno0bKu2e2xrg==
+"@types/node@^14.6.2":
+  version "14.17.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.4.tgz#218712242446fc868d0e007af29a4408c7765bc0"
+  integrity sha512-8kQ3+wKGRNN0ghtEn7EGps/B8CzuBz1nXZEIGGLP2GnwbqYn4dbTs7k+VKLTq1HvZLRCIDtN3Snx1Ege8B7L5A==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -4986,13 +4986,13 @@ electron-to-chromium@^1.3.413:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.464.tgz#fe13feaa08f6f865d3c89d5d72e54c194f463aa5"
   integrity sha512-Oo+0+CN9d2z6FToQW6Hwvi9ez09Y/usKwr0tsDsyg43a871zVJCi1nR0v03djLbRNcaCKjtrnVf2XJhTxEpPCg==
 
-electron@^9.0.4:
-  version "9.0.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-9.0.4.tgz#5aa72c1576c82c19f6e087311ffe1d7b74358d25"
-  integrity sha512-QzkeZNAiNB7KxcdoQKSoaiVT/GQdB4Vt0/ZZOuU8tIKABAsni2I7ztiAbUzxcsnQsqEBSfChuPuDQ5A4VbbzPg==
+electron@^13.1.5:
+  version "13.1.5"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-13.1.5.tgz#faa6127ac3428ec12c14779a6fe0a89b150ce614"
+  integrity sha512-ZoMCcPQNs/zO/Zdb5hq5H+rwRaKrdI3/sfXEwBVMx7f5jwa9jPQB3dZ2+7t59uD9VcFAWsH/pozr8nPPlv0tyw==
   dependencies:
     "@electron/get" "^1.0.1"
-    "@types/node" "^12.0.12"
+    "@types/node" "^14.6.2"
     extract-zip "^1.0.3"
 
 elliptic@^6.0.0, elliptic@^6.5.2:


### PR DESCRIPTION
### The Problem

The current version (as in our `package.json`) of electron does not support Apple Silicon (M1) so if you try to run `yarn install`, you will get the error shown in the screenshot below. It basically says that there is no `arm64` release for electron v9.

![Screenshot 2021-07-05 at 13 36 58](https://user-images.githubusercontent.com/6333409/124472575-34775200-dd96-11eb-909c-2a824f1cb15d.png)

### Solution

I've updated the version of electron to the latest which also supports `arm64`. Screenshot below was taken once I updated electron.

Ps. I also had to disable [`contextIsolation`](https://www.electronjs.org/docs/tutorial/context-isolation) which is now enabled by default (as of electron v12).

![Screenshot 2021-07-05 at 13 40 48](https://user-images.githubusercontent.com/6333409/124473045-bff0e300-dd96-11eb-8b28-dd51263adb0a.png)
