### PR TITLE
fix: Allows urql-devtools to launch via Windows PowerShell

### DIFF
--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 const { spawn } = require("child_process");
-spawn("npm", ["start"], { stdio: "inherit", cwd: `${__dirname}/..` });
+spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ["start"], { stdio: "inherit", cwd: `${__dirname}/..` });


### PR DESCRIPTION
Resolves an issue where in powershell "npm" is not a valid command, and uses the correct "npm.cmd" executable instead. Test plan ran since checkout on windows has issues:

* install globally via npm install -g urql-devtools
* cd into the AppData/roaming directory for node_modules
* make change directly to the cli.js file
* launch using the global bin command "urql-devtools"

Fixes: #377